### PR TITLE
Add secrets.yml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@ pickle-email-*.html
 
 # TODO Comment out these rules if you are OK with secrets being uploaded to the repo
 config/initializers/secret_token.rb
-config/secrets.yml
+# config/secrets.yml
 
 # dotenv
 # TODO Comment out this rule if environment variables can be committed

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -1,0 +1,22 @@
+# Be sure to restart your server when you modify this file.
+
+# Your secret key is used for verifying the integrity of signed cookies.
+# If you change this key, all old signed cookies will become invalid!
+
+# Make sure the secret is at least 30 characters and all random,
+# no regular words or you'll be exposed to dictionary attacks.
+# You can use `rake secret` to generate a secure secret key.
+
+# Make sure the secrets in this file are kept private
+# if you're sharing your code publicly.
+
+development:
+  secret_key_base: 81a8b14af455cfd84567e398a2f051eb834e08d48e885444b0193cf17630edcb8f8a699cf492ee140f0fd0beaea30a1fd1ba6207c6ae7fd8434f24ca4d9a32d9
+
+test:
+  secret_key_base: b25f4a1674cd7771fb9a9e60dbb0eb23ab2251196c3b15944f17e8e221c27d65abd36442b4d37e819c0262fc737897d5b4a7e1f262bfee51c28f0f87bfa7512a
+
+# Do not keep production secrets in the repository,
+# instead read values from the environment.
+production:
+  secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>


### PR DESCRIPTION
This PR removes secrets.yml from the gitignore. It's controlled by an ENV but the file has to exist in production for a successful Heroku deploy.